### PR TITLE
Copy original request uri and headers when querying all pages

### DIFF
--- a/GraphQlClient.Relay/Client/GraphQlRelayClient.cs
+++ b/GraphQlClient.Relay/Client/GraphQlRelayClient.cs
@@ -33,12 +33,20 @@ namespace GraphQlClient.Relay
                     Response = response
                 });
 
-                response = await SendAsync<TResponse, TResponseData>(new GraphQlRequestMessage
+                var pageRequest = new GraphQlRequestMessage
                 {
                     OperationName = request.OperationName,
                     Query = queryString,
-                    Variables = request.Variables
-                });
+                    Variables = request.Variables,
+                    RequestUri = request.RequestUri
+                };
+
+                foreach (var header in request.Headers)
+                {
+                    pageRequest.Headers.Add(header.Key, header.Value);
+                }
+
+                response = await SendAsync<TResponse, TResponseData>(pageRequest);
 
                 result.Add(response);
             }

--- a/GraphQlClient.Relay/GraphQlClient.Relay.csproj
+++ b/GraphQlClient.Relay/GraphQlClient.Relay.csproj
@@ -4,7 +4,7 @@
     <Authors>Carlos Rodríguez Contreras</Authors>
     <PackageDescription>Library to simplify making GraphQl requests to Relay-based servers</PackageDescription>
     <PackageId>Karrocon.GraphQlClient.Relay</PackageId>
-    <PackageVersion>0.7.0</PackageVersion>
+    <PackageVersion>0.7.1</PackageVersion>
     <TargetFrameworks>netcoreapp2.1;netstandard2.0;net45</TargetFrameworks>
     <Title>Karrocon.GraphQlClient.Relay</Title>
   </PropertyGroup>

--- a/GraphQlClient/GraphQlClient.csproj
+++ b/GraphQlClient/GraphQlClient.csproj
@@ -4,7 +4,7 @@
     <Authors>Carlos Rodríguez Contreras</Authors>
     <PackageDescription>Library to simplify making GraphQl requests</PackageDescription>
     <PackageId>Karrocon.GraphQlClient</PackageId>
-    <PackageVersion>0.7.0</PackageVersion>
+    <PackageVersion>0.7.1</PackageVersion>
     <TargetFrameworks>netcoreapp2.1;netstandard2.0;net45</TargetFrameworks>
     <Title>Karrocon.GraphQlClient</Title>
   </PropertyGroup>


### PR DESCRIPTION
When querying all pages, is more than one page is requested, the RequestUri and Headers from the original request are lost in subsequent queries.